### PR TITLE
Add delivery deadlines and company sorting

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -133,12 +133,13 @@ Track outgoing deliveries. Use `switch` or the Deliveries tab to get here from t
 
 |Command|Format|Example|
 |-|-|-|
-|Add|`add pr/PRODUCT c/COMPANY a/ADDRESS \[t/TAG]...`|`add pr/Industrial Printer c/Acme Supplies a/10 Anson Road t/urgent`|
-|Edit|`edit INDEX \[pr/PRODUCT] \[c/COMPANY] \[a/ADDRESS] \[t/TAG]...`|`edit 1 a/20 Harbour Front Walk t/fragile`|
+|Add|`add pr/PRODUCT c/COMPANY dl/DEADLINE a/ADDRESS \[t/TAG]...`|`add pr/Industrial Printer c/Acme Supplies dl/2026-03-25 14:30 a/10 Anson Road t/urgent`|
+|Edit|`edit INDEX \[pr/PRODUCT] \[c/COMPANY] \[dl/DEADLINE] \[a/ADDRESS] \[t/TAG]...`|`edit 1 dl/2026-03-26 09:00 a/20 Harbour Front Walk t/fragile`|
 |Delete|`delete INDEX`|`delete 2`|
 |Mark delivered|`mark INDEX`|`mark 1`|
 |Unmark|`unmark INDEX`|`unmark 1`|
 |Find|`find KEYWORD \[MORE\_KEYWORDS]...`|`find printer laptop`|
+|Sort by deadline|`sort c/COMPANY`|`sort c/Acme Supplies`|
 |Clear all|`clear`|`clear`|
 
 **Delivery prefixes:**
@@ -147,8 +148,11 @@ Track outgoing deliveries. Use `switch` or the Deliveries tab to get here from t
 |-|-|-|
 |`pr/`|Product name|Yes|
 |`c/`|Company name|Yes|
+|`dl/`|Deadline (`yyyy-MM-dd HH:mm`)|Yes for `add`, optional for `edit`|
 |`a/`|Delivery address|Yes|
 |`t/`|Tag (repeatable)|No|
+
+Deliveries are sorted by deadline in ascending order, so the earliest deadline appears first.
 
 \---
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -57,12 +57,15 @@ public class Messages {
      */
     public static String format(Delivery delivery) {
         final StringBuilder builder = new StringBuilder();
-        builder.append(delivery.getProduct())
-                .append("; Product: ")
-                .append(delivery.getCompany())
+        builder.append("Product: ")
+                .append(delivery.getProduct())
                 .append("; Company: ")
+                .append(delivery.getCompany())
+                .append("; Deadline: ")
+                .append(delivery.getDeadline())
+                .append("; Address: ")
                 .append(delivery.getAddress())
-                .append("; Address: ");
+                .append("; Tags: ");
         delivery.getTags().forEach(builder::append);
         return builder.toString();
     }

--- a/src/main/java/seedu/address/logic/commands/deliverycommands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliverycommands/AddCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands.deliverycommands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -24,11 +25,13 @@ public class AddCommand extends Command {
             + "Parameters: "
             + PREFIX_PRODUCT + "PRODUCT "
             + PREFIX_COMPANY + "COMPANY "
+            + PREFIX_DEADLINE + "DEADLINE "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_PRODUCT + "Laptop "
             + PREFIX_COMPANY + "Dell "
+            + PREFIX_DEADLINE + "2026-03-25 14:30 "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_TAG + "urgent";
 

--- a/src/main/java/seedu/address/logic/commands/deliverycommands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliverycommands/EditCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands.deliverycommands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_DELIVERIES;
@@ -24,6 +25,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.delivery.Address;
 import seedu.address.model.delivery.Company;
+import seedu.address.model.delivery.Deadline;
 import seedu.address.model.delivery.Delivery;
 import seedu.address.model.delivery.Product;
 import seedu.address.model.tag.Tag;
@@ -41,11 +43,13 @@ public class EditCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_PRODUCT + "PRODUCT] "
             + "[" + PREFIX_COMPANY + "delivery] "
+            + "[" + PREFIX_DEADLINE + "DEADLINE] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PRODUCT + "Laptop"
-            + PREFIX_COMPANY + "Dell";
+            + PREFIX_COMPANY + "Dell "
+            + PREFIX_DEADLINE + "2026-03-25 14:30";
 
     public static final String MESSAGE_EDIT_DELIVERY_SUCCESS = "Edited Delivery: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
@@ -97,10 +101,11 @@ public class EditCommand extends Command {
 
         Product updatedProduct = editDeliveryDescriptor.getProduct().orElse(deliveryToEdit.getProduct());
         Company updatedCompany = editDeliveryDescriptor.getCompany().orElse(deliveryToEdit.getCompany());
+        Deadline updatedDeadline = editDeliveryDescriptor.getDeadline().orElse(deliveryToEdit.getDeadline());
         Address updatedAddress = editDeliveryDescriptor.getAddress().orElse(deliveryToEdit.getAddress());
         Set<Tag> updatedTags = editDeliveryDescriptor.getTags().orElse(deliveryToEdit.getTags());
 
-        return new Delivery(updatedProduct, updatedCompany, updatedAddress, updatedTags);
+        return new Delivery(updatedProduct, updatedCompany, updatedDeadline, updatedAddress, updatedTags);
     }
 
     @Override
@@ -134,6 +139,7 @@ public class EditCommand extends Command {
     public static class EditDeliveryDescriptor {
         private Product product;
         private Company company;
+        private Deadline deadline;
         private Address address;
         private Set<Tag> tags;
 
@@ -146,6 +152,7 @@ public class EditCommand extends Command {
         public EditDeliveryDescriptor(EditDeliveryDescriptor toCopy) {
             setProduct(toCopy.product);
             setCompany(toCopy.company);
+            setDeadline(toCopy.deadline);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
         }
@@ -154,7 +161,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(product, company, address, tags);
+            return CollectionUtil.isAnyNonNull(product, company, deadline, address, tags);
         }
 
         public void setProduct(Product product) {
@@ -171,6 +178,14 @@ public class EditCommand extends Command {
 
         public Optional<Company> getCompany() {
             return Optional.ofNullable(company);
+        }
+
+        public void setDeadline(Deadline deadline) {
+            this.deadline = deadline;
+        }
+
+        public Optional<Deadline> getDeadline() {
+            return Optional.ofNullable(deadline);
         }
 
         public void setAddress(Address address) {
@@ -212,6 +227,7 @@ public class EditCommand extends Command {
             EditDeliveryDescriptor otherEditDeliveryDescriptor = (EditDeliveryDescriptor) other;
             return Objects.equals(product, otherEditDeliveryDescriptor.product)
                     && Objects.equals(company, otherEditDeliveryDescriptor.company)
+                    && Objects.equals(deadline, otherEditDeliveryDescriptor.deadline)
                     && Objects.equals(address, otherEditDeliveryDescriptor.address)
                     && Objects.equals(tags, otherEditDeliveryDescriptor.tags);
         }
@@ -221,6 +237,7 @@ public class EditCommand extends Command {
             return new ToStringBuilder(this)
                     .add("product", product)
                     .add("company", company)
+                    .add("deadline", deadline)
                     .add("address", address)
                     .add("tags", tags)
                     .toString();

--- a/src/main/java/seedu/address/logic/commands/deliverycommands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliverycommands/MarkCommand.java
@@ -54,6 +54,7 @@ public class MarkCommand extends Command {
         Delivery markedDelivery = new Delivery(
                 deliveryToMark.getProduct(),
                 deliveryToMark.getCompany(),
+                deliveryToMark.getDeadline(),
                 deliveryToMark.getAddress(),
                 newTags
         );

--- a/src/main/java/seedu/address/logic/commands/deliverycommands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliverycommands/SortCommand.java
@@ -1,0 +1,79 @@
+package seedu.address.logic.commands.deliverycommands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.delivery.Company;
+import seedu.address.model.delivery.Delivery;
+
+/**
+ * Sorts a company's deliveries by deadline, with the earliest deadline shown first.
+ */
+public class SortCommand extends Command {
+
+    public static final String COMMAND_WORD = "sort";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts deliveries for a company by deadline, "
+            + "with the earliest deadline first.\n"
+            + "Parameters: " + PREFIX_COMPANY + "COMPANY\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_COMPANY + "Dell";
+
+    public static final String MESSAGE_SORT_SUCCESS = "Sorted %1$d delivery(s) for company: %2$s";
+    public static final String MESSAGE_NO_DELIVERIES_FOR_COMPANY = "No deliveries found for company: %1$s";
+
+    private final Company company;
+
+    /**
+     * Creates a SortCommand to sort deliveries for the specified company.
+     */
+    public SortCommand(Company company) {
+        requireNonNull(company);
+        this.company = company;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        Predicate<Delivery> matchesCompany = delivery -> delivery.getCompany().value.equalsIgnoreCase(company.value);
+
+        boolean hasMatchingDelivery = model.getDeliveryBook().getDeliveryList().stream()
+                .anyMatch(matchesCompany);
+        if (!hasMatchingDelivery) {
+            throw new CommandException(String.format(MESSAGE_NO_DELIVERIES_FOR_COMPANY, company));
+        }
+
+        model.sortDeliveriesByDeadline(matchesCompany);
+        model.updateFilteredDeliveryList(matchesCompany);
+
+        return new CommandResult(
+                String.format(MESSAGE_SORT_SUCCESS, model.getFilteredDeliveryList().size(), company));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof SortCommand)) {
+            return false;
+        }
+
+        SortCommand otherSortCommand = (SortCommand) other;
+        return company.equals(otherSortCommand.company);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("company", company)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/deliverycommands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliverycommands/UnmarkCommand.java
@@ -55,6 +55,7 @@ public class UnmarkCommand extends Command {
         Delivery unmarkedDelivery = new Delivery(
                 deliveryToUnmark.getProduct(),
                 deliveryToUnmark.getCompany(),
+                deliveryToUnmark.getDeadline(),
                 deliveryToUnmark.getAddress(),
                 newTags
         );

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,5 +14,6 @@ public class CliSyntax {
 
     public static final Prefix PREFIX_PRODUCT = new Prefix("pr/");
     public static final Prefix PREFIX_COMPANY = new Prefix("c/");
+    public static final Prefix PREFIX_DEADLINE = new Prefix("dl/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,6 +14,7 @@ import seedu.address.model.company.Email;
 import seedu.address.model.company.Name;
 import seedu.address.model.company.Phone;
 import seedu.address.model.delivery.Company;
+import seedu.address.model.delivery.Deadline;
 import seedu.address.model.delivery.Product;
 import seedu.address.model.tag.Tag;
 
@@ -140,6 +141,21 @@ public class ParserUtil {
             throw new ParseException(Company.MESSAGE_CONSTRAINTS);
         }
         return new Company(trimmedCompany);
+    }
+
+    /**
+     * Parses a {@code String deadline} into a {@code Deadline}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code deadline} is invalid.
+     */
+    public static Deadline parseDeadline(String deadline) throws ParseException {
+        requireNonNull(deadline);
+        String trimmedDeadline = deadline.trim();
+        if (!Deadline.isValidDeadline(trimmedDeadline)) {
+            throw new ParseException(Deadline.MESSAGE_CONSTRAINTS);
+        }
+        return new Deadline(trimmedDeadline);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/deliveryparser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/deliveryparser/AddCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser.deliveryparser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -18,6 +19,7 @@ import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.delivery.Address;
 import seedu.address.model.delivery.Company;
+import seedu.address.model.delivery.Deadline;
 import seedu.address.model.delivery.Delivery;
 import seedu.address.model.delivery.Product;
 import seedu.address.model.tag.Tag;
@@ -34,20 +36,22 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT, PREFIX_COMPANY, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT, PREFIX_COMPANY, PREFIX_DEADLINE, PREFIX_ADDRESS,
+                        PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_PRODUCT, PREFIX_ADDRESS, PREFIX_COMPANY)
+        if (!arePrefixesPresent(argMultimap, PREFIX_PRODUCT, PREFIX_COMPANY, PREFIX_DEADLINE, PREFIX_ADDRESS)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PRODUCT, PREFIX_COMPANY, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PRODUCT, PREFIX_COMPANY, PREFIX_DEADLINE, PREFIX_ADDRESS);
         Product product = ParserUtil.parseProduct(argMultimap.getValue(PREFIX_PRODUCT).get());
         Company company = ParserUtil.parseCompany(argMultimap.getValue(PREFIX_COMPANY).get());
+        Deadline deadline = ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE).get());
         Address address = ParserUtil.parseDeliveryAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Delivery delivery = new Delivery(product, company, address, tagList);
+        Delivery delivery = new Delivery(product, company, deadline, address, tagList);
 
         return new AddCommand(delivery);
     }

--- a/src/main/java/seedu/address/logic/parser/deliveryparser/DeliveryBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/deliveryparser/DeliveryBookParser.java
@@ -12,8 +12,10 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.deliverycommands.AddCommand;
 import seedu.address.logic.commands.deliverycommands.ClearCommand;
 import seedu.address.logic.commands.deliverycommands.DeleteCommand;
+import seedu.address.logic.commands.deliverycommands.EditCommand;
 import seedu.address.logic.commands.deliverycommands.FindCommand;
 import seedu.address.logic.commands.deliverycommands.MarkCommand;
+import seedu.address.logic.commands.deliverycommands.SortCommand;
 import seedu.address.logic.commands.deliverycommands.SwitchCommand;
 import seedu.address.logic.commands.deliverycommands.UnmarkCommand;
 import seedu.address.logic.commands.uicommand.ExitCommand;
@@ -64,11 +66,17 @@ public class DeliveryBookParser {
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
 
+        case EditCommand.COMMAND_WORD:
+            return new EditCommandParser().parse(arguments);
+
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
         case MarkCommand.COMMAND_WORD:
             return new MarkCommandParser().parse(arguments);
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
 
         case UnmarkCommand.COMMAND_WORD:
             return new UnmarkCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/deliveryparser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/deliveryparser/EditCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -35,7 +36,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT, PREFIX_COMPANY, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT, PREFIX_COMPANY, PREFIX_DEADLINE, PREFIX_ADDRESS,
+                        PREFIX_TAG);
 
         Index index;
 
@@ -45,7 +47,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PRODUCT, PREFIX_COMPANY, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PRODUCT, PREFIX_COMPANY, PREFIX_DEADLINE, PREFIX_ADDRESS);
 
         EditCommand.EditDeliveryDescriptor editDeliveryDescriptor = new EditDeliveryDescriptor();
 
@@ -54,6 +56,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_COMPANY).isPresent()) {
             editDeliveryDescriptor.setCompany(ParserUtil.parseCompany(argMultimap.getValue(PREFIX_COMPANY).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DEADLINE).isPresent()) {
+            editDeliveryDescriptor.setDeadline(ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE).get()));
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editDeliveryDescriptor.setAddress(

--- a/src/main/java/seedu/address/logic/parser/deliveryparser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/deliveryparser/SortCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser.deliveryparser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+
+import seedu.address.logic.commands.deliverycommands.SortCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.delivery.Company;
+
+/**
+ * Parses input arguments and creates a new SortCommand object.
+ */
+public class SortCommandParser implements Parser<SortCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SortCommand
+     * and returns a SortCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SortCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_COMPANY);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_COMPANY) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_COMPANY);
+        Company company = ParserUtil.parseCompany(argMultimap.getValue(PREFIX_COMPANY).get());
+        return new SortCommand(company);
+    }
+
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        for (Prefix prefix : prefixes) {
+            if (!argumentMultimap.getValue(prefix).isPresent()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/seedu/address/model/DeliveryBook.java
+++ b/src/main/java/seedu/address/model/DeliveryBook.java
@@ -2,8 +2,10 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
@@ -84,6 +86,23 @@ public class DeliveryBook implements ReadOnlyDeliveryBook {
     public void setDelivery(Delivery target, Delivery editedDelivery) {
         requireNonNull(editedDelivery);
         deliveries.setDelivery(target, editedDelivery);
+    }
+
+    /**
+     * Sorts deliveries by the given comparator.
+     */
+    public void sortDeliveries(Comparator<Delivery> comparator) {
+        requireNonNull(comparator);
+        deliveries.sort(comparator);
+    }
+
+    /**
+     * Sorts only deliveries matching the predicate by the given comparator.
+     */
+    public void sortDeliveries(Predicate<Delivery> predicate, Comparator<Delivery> comparator) {
+        requireNonNull(predicate);
+        requireNonNull(comparator);
+        deliveries.sortMatching(predicate, comparator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -113,6 +113,8 @@ public interface Model {
 
     void setDelivery(Delivery delivery, Delivery editedDelivery);
 
+    void sortDeliveriesByDeadline(Predicate<Delivery> predicate);
+
     ObservableList<Delivery> getFilteredDeliveryList();
 
     void updateFilteredDeliveryList(Predicate<Delivery> predicate);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -19,6 +20,10 @@ import seedu.address.model.delivery.Delivery;
  */
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
+    private static final Comparator<Delivery> DELIVERY_DEADLINE_COMPARATOR = Comparator
+            .comparing((Delivery delivery) -> delivery.getDeadline().getValue())
+            .thenComparing(delivery -> delivery.getCompany().value.toLowerCase())
+            .thenComparing(delivery -> delivery.getProduct().productName.toLowerCase());
 
     private final AddressBook addressBook;
     private final DeliveryBook deliveryBook;
@@ -181,6 +186,12 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedDelivery);
         deliveryBook.setDelivery(target, editedDelivery);
         updateFilteredDeliveryList(deliveryItem -> true);
+    }
+
+    @Override
+    public void sortDeliveriesByDeadline(Predicate<Delivery> predicate) {
+        requireNonNull(predicate);
+        deliveryBook.sortDeliveries(predicate, DELIVERY_DEADLINE_COMPARATOR);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/delivery/Deadline.java
+++ b/src/main/java/seedu/address/model/delivery/Deadline.java
@@ -1,0 +1,90 @@
+package seedu.address.model.delivery;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+
+/**
+ * Represents a Delivery deadline.
+ * Guarantees: immutable; is valid as declared in {@link #isValidDeadline(String)}
+ */
+public class Deadline {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Deadline should follow the format yyyy-MM-dd HH:mm";
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter
+            .ofPattern("uuuu-MM-dd HH:mm")
+            .withResolverStyle(ResolverStyle.STRICT);
+
+    private final LocalDateTime value;
+
+    /**
+     * Constructs a {@code Deadline}.
+     *
+     * @param deadline A valid deadline string.
+     */
+    public Deadline(String deadline) {
+        requireNonNull(deadline);
+        checkArgument(isValidDeadline(deadline), MESSAGE_CONSTRAINTS);
+        value = LocalDateTime.parse(deadline, FORMATTER);
+    }
+
+    /**
+     * Constructs a {@code Deadline}.
+     *
+     * @param deadline A valid {@code LocalDateTime}.
+     */
+    public Deadline(LocalDateTime deadline) {
+        requireNonNull(deadline);
+        value = deadline;
+    }
+
+    /**
+     * Returns true if a given string is a valid deadline.
+     */
+    public static boolean isValidDeadline(String test) {
+        requireNonNull(test);
+        try {
+            LocalDateTime.parse(test, FORMATTER);
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+
+    public LocalDateTime getValue() {
+        return value;
+    }
+
+    public String toStorageString() {
+        return value.format(FORMATTER);
+    }
+
+    @Override
+    public String toString() {
+        return toStorageString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Deadline)) {
+            return false;
+        }
+
+        Deadline otherDeadline = (Deadline) other;
+        return value.equals(otherDeadline.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/delivery/Delivery.java
+++ b/src/main/java/seedu/address/model/delivery/Delivery.java
@@ -19,6 +19,7 @@ public class Delivery {
     // Identity fields
     private final Product product;
     private final Company company;
+    private final Deadline deadline;
 
     // Data fields
     private final Address address;
@@ -27,10 +28,11 @@ public class Delivery {
     /**
      * Every field must be present and not null.
      */
-    public Delivery(Product product, Company company, Address address, Set<Tag> tags) {
-        requireAllNonNull(product, company, address, tags);
+    public Delivery(Product product, Company company, Deadline deadline, Address address, Set<Tag> tags) {
+        requireAllNonNull(product, company, deadline, address, tags);
         this.product = product;
         this.company = company;
+        this.deadline = deadline;
         this.address = address;
         this.tags.addAll(tags);
     }
@@ -41,6 +43,10 @@ public class Delivery {
 
     public Company getCompany() {
         return company;
+    }
+
+    public Deadline getDeadline() {
+        return deadline;
     }
 
     public Address getAddress() {
@@ -65,7 +71,9 @@ public class Delivery {
         }
 
         return otherDelivery != null
-                && otherDelivery.getProduct().equals(getProduct());
+                && otherDelivery.getProduct().equals(getProduct())
+                && otherDelivery.getCompany().equals(getCompany())
+                && otherDelivery.getDeadline().equals(getDeadline());
     }
 
     /**
@@ -86,6 +94,7 @@ public class Delivery {
         Delivery otherDelivery = (Delivery) other;
         return product.equals(otherDelivery.product)
                 && company.equals(otherDelivery.company)
+                && deadline.equals(otherDelivery.deadline)
                 && address.equals(otherDelivery.address)
                 && tags.equals(otherDelivery.tags);
     }
@@ -93,7 +102,7 @@ public class Delivery {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(product, company, address, tags);
+        return Objects.hash(product, company, deadline, address, tags);
     }
 
     @Override
@@ -101,6 +110,7 @@ public class Delivery {
         return new ToStringBuilder(this)
                 .add("product", product)
                 .add("company", company)
+                .add("deadline", deadline)
                 .add("address", address)
                 .add("tags", tags)
                 .toString();

--- a/src/main/java/seedu/address/model/delivery/UniqueDeliveryList.java
+++ b/src/main/java/seedu/address/model/delivery/UniqueDeliveryList.java
@@ -3,8 +3,12 @@ package seedu.address.model.delivery;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -96,6 +100,34 @@ public class UniqueDeliveryList implements Iterable<Delivery> {
         }
 
         internalList.setAll(deliveries);
+    }
+
+    /**
+     * Sorts the deliveries by the given comparator.
+     */
+    public void sort(Comparator<Delivery> comparator) {
+        requireNonNull(comparator);
+        FXCollections.sort(internalList, comparator);
+    }
+
+    /**
+     * Sorts only deliveries matching the predicate while preserving the positions of non-matching deliveries.
+     */
+    public void sortMatching(Predicate<Delivery> predicate, Comparator<Delivery> comparator) {
+        requireNonNull(predicate);
+        requireNonNull(comparator);
+
+        List<Delivery> sortedMatches = internalList.stream()
+                .filter(predicate)
+                .sorted(comparator)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        int replacementIndex = 0;
+        for (int i = 0; i < internalList.size(); i++) {
+            if (predicate.test(internalList.get(i))) {
+                internalList.set(i, sortedMatches.get(replacementIndex++));
+            }
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDeliveryDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDeliveryDataUtil.java
@@ -8,6 +8,7 @@ import seedu.address.model.DeliveryBook;
 import seedu.address.model.ReadOnlyDeliveryBook;
 import seedu.address.model.delivery.Address;
 import seedu.address.model.delivery.Company;
+import seedu.address.model.delivery.Deadline;
 import seedu.address.model.delivery.Delivery;
 import seedu.address.model.delivery.Product;
 import seedu.address.model.tag.Tag;
@@ -18,8 +19,8 @@ import seedu.address.model.tag.Tag;
 public class SampleDeliveryDataUtil {
     public static Delivery[] getSampleCompanies() {
         return new Delivery[] {
-            new Delivery(new Product("laptop"), new Company("Dell"), new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("fragile"))
+            new Delivery(new Product("laptop"), new Company("Dell"), new Deadline("2026-03-25 14:30"),
+                    new Address("Blk 30 Geylang Street 29, #06-40"), getTagSet("fragile"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedDelivery.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedDelivery.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.delivery.Address;
 import seedu.address.model.delivery.Company;
+import seedu.address.model.delivery.Deadline;
 import seedu.address.model.delivery.Delivery;
 import seedu.address.model.delivery.Product;
 import seedu.address.model.tag.Tag;
@@ -25,6 +26,7 @@ class JsonAdaptedDelivery {
 
     private final String product;
     private final String company;
+    private final String deadline;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
@@ -34,10 +36,12 @@ class JsonAdaptedDelivery {
     @JsonCreator
     public JsonAdaptedDelivery(@JsonProperty("product") String product,
                                @JsonProperty("company") String company,
+                               @JsonProperty("deadline") String deadline,
                                @JsonProperty("address") String address,
                                @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.product = product;
         this.company = company;
+        this.deadline = deadline;
         this.address = address;
         if (tags != null) {
             this.tags.addAll(tags);
@@ -50,6 +54,7 @@ class JsonAdaptedDelivery {
     public JsonAdaptedDelivery(Delivery source) {
         product = source.getProduct().productName;
         company = source.getCompany().value;
+        deadline = source.getDeadline().toStorageString();
         address = source.getAddress().value;
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
@@ -83,6 +88,15 @@ class JsonAdaptedDelivery {
         }
         final Company modelCompany = new Company(company);
 
+        if (deadline == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, Deadline.class.getSimpleName()));
+        }
+        if (!Deadline.isValidDeadline(deadline)) {
+            throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS);
+        }
+        final Deadline modelDeadline = new Deadline(deadline);
+
         if (address == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
         }
@@ -92,7 +106,7 @@ class JsonAdaptedDelivery {
         final Address modelAddress = new Address(address);
 
         final Set<Tag> modelTags = new HashSet<>(companyTags);
-        return new Delivery(modelProduct, modelCompany, modelAddress, modelTags);
+        return new Delivery(modelProduct, modelCompany, modelDeadline, modelAddress, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/ui/DeliveryCard.java
+++ b/src/main/java/seedu/address/ui/DeliveryCard.java
@@ -35,6 +35,8 @@ public class DeliveryCard extends UiPart<Region> {
     @FXML
     private Label company;
     @FXML
+    private Label deadline;
+    @FXML
     private Label address;
     @FXML
     private FlowPane tags;
@@ -48,6 +50,7 @@ public class DeliveryCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         product.setText(delivery.getProduct().productName);
         company.setText(delivery.getCompany().value);
+        deadline.setText("Deadline: " + delivery.getDeadline());
         address.setText(delivery.getAddress().value);
         delivery.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/resources/view/DeliveryListCard.fxml
+++ b/src/main/resources/view/DeliveryListCard.fxml
@@ -28,6 +28,7 @@
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="company" styleClass="cell_small_label" text="$company" />
+      <Label fx:id="deadline" styleClass="cell_small_label" text="$deadline" />
       <Label fx:id="address" styleClass="cell_small_label" text="$address" />
     </VBox>
   </GridPane>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -193,6 +193,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void sortDeliveriesByDeadline(Predicate<Delivery> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasDelivery(Delivery delivery) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.deliverycommands.SortCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.DeliveryBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.delivery.Address;
+import seedu.address.model.delivery.Company;
+import seedu.address.model.delivery.Deadline;
+import seedu.address.model.delivery.Delivery;
+import seedu.address.model.delivery.Product;
+
+public class SortCommandTest {
+
+    @Test
+    public void execute_companyDeliveriesSortedByDeadline_success() throws Exception {
+        Delivery laterDell = new Delivery(new Product("Laptop"), new Company("Dell"),
+                new Deadline("2026-03-26 10:00"), new Address("10 Anson Road"), Collections.emptySet());
+        Delivery earlierDell = new Delivery(new Product("Printer"), new Company("Dell"),
+                new Deadline("2026-03-25 09:00"), new Address("11 Anson Road"), Collections.emptySet());
+        Delivery acerDelivery = new Delivery(new Product("Monitor"), new Company("Acer"),
+                new Deadline("2026-03-24 08:00"), new Address("12 Anson Road"), Collections.emptySet());
+
+        Model model = new ModelManager(new seedu.address.model.AddressBook(), new DeliveryBook(), new UserPrefs());
+        model.addDelivery(laterDell);
+        model.addDelivery(earlierDell);
+        model.addDelivery(acerDelivery);
+
+        SortCommand command = new SortCommand(new Company("Dell"));
+        CommandResult result = command.execute(model);
+
+        assertEquals(String.format(SortCommand.MESSAGE_SORT_SUCCESS, 2, "Dell"), result.getFeedbackToUser());
+        assertEquals(2, model.getFilteredDeliveryList().size());
+        assertEquals(earlierDell, model.getFilteredDeliveryList().get(0));
+        assertEquals(laterDell, model.getFilteredDeliveryList().get(1));
+        assertEquals(List.of(earlierDell, laterDell, acerDelivery), model.getDeliveryBook().getDeliveryList());
+    }
+
+    @Test
+    public void execute_missingCompanyDelivery_throwsCommandException() {
+        Model model = new ModelManager(new seedu.address.model.AddressBook(), new DeliveryBook(), new UserPrefs());
+        SortCommand command = new SortCommand(new Company("Dell"));
+        String expectedMessage = String.format(SortCommand.MESSAGE_NO_DELIVERIES_FOR_COMPANY, "Dell");
+
+        assertThrows(CommandException.class, expectedMessage, () -> command.execute(model));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeliveryBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeliveryBookParserTest.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.deliverycommands.EditCommand;
+import seedu.address.logic.commands.deliverycommands.EditCommand.EditDeliveryDescriptor;
+import seedu.address.logic.parser.deliveryparser.DeliveryBookParser;
+import seedu.address.model.delivery.Deadline;
+
+public class DeliveryBookParserTest {
+
+    private final DeliveryBookParser parser = new DeliveryBookParser();
+
+    @Test
+    public void parseCommand_editDeadline() throws Exception {
+        EditDeliveryDescriptor descriptor = new EditDeliveryDescriptor();
+        descriptor.setDeadline(new Deadline("2026-03-26 09:00"));
+
+        EditCommand command = (EditCommand) parser.parseCommand("edit "
+                + INDEX_FIRST_PERSON.getOneBased() + " dl/2026-03-26 09:00");
+
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.deliverycommands.SortCommand;
+import seedu.address.logic.parser.deliveryparser.SortCommandParser;
+import seedu.address.model.delivery.Company;
+
+public class SortCommandParserTest {
+
+    private final SortCommandParser parser = new SortCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsSortCommand() {
+        assertParseSuccess(parser, " c/Dell", new SortCommand(new Company("Dell")));
+    }
+
+    @Test
+    public void parse_missingCompany_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_duplicateCompany_throwsParseException() {
+        assertParseFailure(parser, " c/Dell c/Acer",
+                Messages.getErrorMessageForDuplicatePrefixes(CliSyntax.PREFIX_COMPANY));
+    }
+}

--- a/src/test/java/seedu/address/model/delivery/DeadlineTest.java
+++ b/src/test/java/seedu/address/model/delivery/DeadlineTest.java
@@ -1,0 +1,35 @@
+package seedu.address.model.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class DeadlineTest {
+
+    @Test
+    public void constructor_invalidDeadline_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new Deadline("2026/03/25 14:30"));
+    }
+
+    @Test
+    public void isValidDeadline() {
+        assertThrows(NullPointerException.class, () -> Deadline.isValidDeadline(null));
+
+        assertFalse(Deadline.isValidDeadline("2026/03/25 14:30"));
+        assertFalse(Deadline.isValidDeadline("2026-03-25"));
+        assertFalse(Deadline.isValidDeadline("14:30 2026-03-25"));
+        assertFalse(Deadline.isValidDeadline("2026-02-29 10:00"));
+        assertFalse(Deadline.isValidDeadline("2026-04-31 10:00"));
+
+        assertTrue(Deadline.isValidDeadline("2026-03-25 14:30"));
+    }
+
+    @Test
+    public void toStorageString_returnsFormattedDeadline() {
+        Deadline deadline = new Deadline("2026-03-25 14:30");
+        assertEquals("2026-03-25 14:30", deadline.toStorageString());
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedDeliveryTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedDeliveryTest.java
@@ -1,0 +1,53 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.storage.JsonAdaptedDelivery.MISSING_FIELD_MESSAGE_FORMAT;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.delivery.Address;
+import seedu.address.model.delivery.Company;
+import seedu.address.model.delivery.Deadline;
+import seedu.address.model.delivery.Delivery;
+import seedu.address.model.delivery.Product;
+import seedu.address.model.tag.Tag;
+
+public class JsonAdaptedDeliveryTest {
+
+    private static final Delivery VALID_DELIVERY = new Delivery(new Product("Laptop"), new Company("Dell"),
+            new Deadline("2026-03-25 14:30"), new Address("10 Anson Road"), Collections.singleton(new Tag("fragile")));
+
+    private static final String VALID_PRODUCT = VALID_DELIVERY.getProduct().toString();
+    private static final String VALID_COMPANY = VALID_DELIVERY.getCompany().toString();
+    private static final String VALID_ADDRESS = VALID_DELIVERY.getAddress().toString();
+    private static final List<JsonAdaptedTag> VALID_TAGS = VALID_DELIVERY.getTags().stream()
+            .map(JsonAdaptedTag::new)
+            .collect(Collectors.toList());
+
+    @Test
+    public void toModelType_validDelivery_returnsDelivery() throws Exception {
+        JsonAdaptedDelivery delivery = new JsonAdaptedDelivery(VALID_DELIVERY);
+        assertEquals(VALID_DELIVERY, delivery.toModelType());
+    }
+
+    @Test
+    public void toModelType_nullDeadline_throwsIllegalValueException() {
+        JsonAdaptedDelivery delivery =
+                new JsonAdaptedDelivery(VALID_PRODUCT, VALID_COMPANY, null, VALID_ADDRESS, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Deadline.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, delivery::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidDeadline_throwsIllegalValueException() {
+        JsonAdaptedDelivery delivery =
+                new JsonAdaptedDelivery(VALID_PRODUCT, VALID_COMPANY, "2026/03/25 14:30", VALID_ADDRESS, VALID_TAGS);
+        assertThrows(IllegalValueException.class, Deadline.MESSAGE_CONSTRAINTS, delivery::toModelType);
+    }
+}


### PR DESCRIPTION
Close #61 

Support required delivery deadlines with validation, editing, storage, and UI updates. Add sorting by company deliveries with tests and parser coverage.